### PR TITLE
Turn type-based constants into runtime-based ones

### DIFF
--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -120,7 +120,7 @@ pub fn make_gradient_covariance_matrices<S: Storage<f64, Dynamic, Dynamic>, K: K
     kernel: &K,
 ) -> Vec<DMatrix<f64>> {
     // empty covariance matrices
-    let mut covmatrices: Vec<_> = (0..K::NB_PARAMETERS)
+    let mut covmatrices: Vec<_> = (0..kernel.nb_parameters())
         .map(|_| DMatrix::<f64>::from_element(inputs.nrows(), inputs.nrows(), std::f64::NAN))
         .collect();
 

--- a/src/gaussian_process/mod.rs
+++ b/src/gaussian_process/mod.rs
@@ -435,7 +435,7 @@ impl<KernelType: Kernel, PriorType: Prior> GaussianProcess<KernelType, PriorType
 
         // fit kernel and retrains model from scratch
         if fit_kernel {
-            if KernelType::IS_SCALABLE {
+            if self.kernel.is_scaleable() {
                 self.scaled_optimize_parameters(max_iter, convergence_fraction);
             } else {
                 self.optimize_parameters(max_iter, convergence_fraction);

--- a/src/parameters/kernel.rs
+++ b/src/parameters/kernel.rs
@@ -21,22 +21,28 @@ use std::ops::{Add, Mul};
 /// If you want to provide a user-defined kernel, you should implement this trait.
 pub trait Kernel: Default {
     /// Numbers of parameters (such as bandwith and amplitude) of the kernel.
-    const NB_PARAMETERS: usize;
+    ///
+    /// This should return a constant value for the kernel.
+    fn nb_parameters(&self) -> usize;
 
-    /// Can the kernel be rescaled (see the `rescale` function) ?
-    /// This value is `false` by default.
-    const IS_SCALABLE: bool = false; // TODO check whether more existing kernel can be made Is_SCALABLE
+    /// Can the kernel be rescaled (see the `rescale` function) ? This value is
+    /// `false` by default.
+    ///
+    /// This should return constant value for the kernel.
+    fn is_scaleable(&self) -> bool {
+        false // TODO check whether more existing kernel can be made is_scaleable
+    }
 
     /// Multiplies the amplitude of the kernel by the `scale` parameter such that a kernel `a*K(x,y)` becomes `scale*a*K(x,y)`
     ///
     /// When possible, do implement this function as it unlock a faster parameter fitting algorithm.
     ///
-    /// *WARNING:* the code will panic if you set `IS_SCALABLE` to `true` without providing a user defined implementation of this function.
+    /// *WARNING:* the code will panic if you set `is_scaleable` to `true` without providing a user defined implementation of this function.
     fn rescale(&mut self, _scale: f64) {
         // TODO get rid of test and add ScalableKernel trait once specialization lands on stable
-        if Self::IS_SCALABLE {
+        if self.is_scaleable() {
             unimplemented!(
-                "Please implement the `rescale` function if you set `IS_SCALABLE` to true."
+                "Please implement the `rescale` function if you set `is_scaleable` to true."
             )
         } else {
             panic!("You tried to rescale a Kernel that is not Scalable!")
@@ -136,8 +142,13 @@ where
     T: Kernel,
     U: Kernel,
 {
-    const NB_PARAMETERS: usize = T::NB_PARAMETERS + U::NB_PARAMETERS;
-    const IS_SCALABLE: bool = T::IS_SCALABLE && U::IS_SCALABLE;
+    fn nb_parameters(&self) -> usize {
+        self.k1.nb_parameters() + self.k2.nb_parameters()
+    }
+
+    fn is_scaleable(&self) -> bool {
+        self.k1.is_scaleable() && self.k2.is_scaleable()
+    }
 
     fn kernel<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
         &self,
@@ -171,8 +182,10 @@ where
     }
 
     fn set_parameters(&mut self, parameters: &[f64]) {
-        self.k1.set_parameters(&parameters[..T::NB_PARAMETERS]);
-        self.k2.set_parameters(&parameters[T::NB_PARAMETERS..]);
+        self.k1
+            .set_parameters(&parameters[..self.k1.nb_parameters()]);
+        self.k2
+            .set_parameters(&parameters[self.k1.nb_parameters()..]);
     }
 
     fn heuristic_fit<SM: Storage<f64, Dynamic, Dynamic>, SV: Storage<f64, Dynamic, U1>>(
@@ -219,8 +232,13 @@ where
     T: Kernel,
     U: Kernel,
 {
-    const NB_PARAMETERS: usize = T::NB_PARAMETERS + U::NB_PARAMETERS;
-    const IS_SCALABLE: bool = T::IS_SCALABLE || U::IS_SCALABLE;
+    fn nb_parameters(&self) -> usize {
+        self.k1.nb_parameters() + self.k2.nb_parameters()
+    }
+
+    fn is_scaleable(&self) -> bool {
+        self.k1.is_scaleable() || self.k2.is_scaleable()
+    }
 
     fn kernel<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
         &self,
@@ -246,7 +264,7 @@ where
     }
 
     fn rescale(&mut self, scale: f64) {
-        if T::IS_SCALABLE {
+        if self.k1.is_scaleable() {
             self.k1.rescale(scale);
         } else {
             self.k2.rescale(scale);
@@ -261,8 +279,10 @@ where
     }
 
     fn set_parameters(&mut self, parameters: &[f64]) {
-        self.k1.set_parameters(&parameters[..T::NB_PARAMETERS]);
-        self.k2.set_parameters(&parameters[T::NB_PARAMETERS..]);
+        self.k1
+            .set_parameters(&parameters[..self.k1.nb_parameters()]);
+        self.k2
+            .set_parameters(&parameters[self.k1.nb_parameters()..]);
     }
 
     fn heuristic_fit<SM: Storage<f64, Dynamic, Dynamic>, SV: Storage<f64, Dynamic, U1>>(
@@ -347,7 +367,9 @@ impl Default for Linear {
 }
 
 impl Kernel for Linear {
-    const NB_PARAMETERS: usize = 1;
+    fn nb_parameters(&self) -> usize {
+        1
+    }
 
     fn kernel<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
         &self,
@@ -422,7 +444,9 @@ impl Default for Polynomial {
 }
 
 impl Kernel for Polynomial {
-    const NB_PARAMETERS: usize = 3;
+    fn nb_parameters(&self) -> usize {
+        3
+    }
 
     fn kernel<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
         &self,
@@ -510,8 +534,13 @@ impl Default for SquaredExp {
 }
 
 impl Kernel for SquaredExp {
-    const NB_PARAMETERS: usize = 2;
-    const IS_SCALABLE: bool = true;
+    fn nb_parameters(&self) -> usize {
+        2
+    }
+
+    fn is_scaleable(&self) -> bool {
+        true
+    }
 
     /// The squared exponential kernel function.
     fn kernel<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
@@ -606,8 +635,13 @@ impl Default for Exponential {
 }
 
 impl Kernel for Exponential {
-    const NB_PARAMETERS: usize = 2;
-    const IS_SCALABLE: bool = true;
+    fn nb_parameters(&self) -> usize {
+        2
+    }
+
+    fn is_scaleable(&self) -> bool {
+        true
+    }
 
     /// The squared exponential kernel function.
     fn kernel<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
@@ -702,8 +736,13 @@ impl Default for Matern1 {
 }
 
 impl Kernel for Matern1 {
-    const NB_PARAMETERS: usize = 2;
-    const IS_SCALABLE: bool = true;
+    fn nb_parameters(&self) -> usize {
+        2
+    }
+
+    fn is_scaleable(&self) -> bool {
+        true
+    }
 
     /// The matèrn1 kernel function.
     fn kernel<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
@@ -800,8 +839,13 @@ impl Default for Matern2 {
 }
 
 impl Kernel for Matern2 {
-    const NB_PARAMETERS: usize = 2;
-    const IS_SCALABLE: bool = true;
+    fn nb_parameters(&self) -> usize {
+        2
+    }
+
+    fn is_scaleable(&self) -> bool {
+        true
+    }
 
     /// The matèrn2 kernel function.
     fn kernel<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
@@ -902,7 +946,9 @@ impl Default for HyperTan {
 }
 
 impl Kernel for HyperTan {
-    const NB_PARAMETERS: usize = 2;
+    fn nb_parameters(&self) -> usize {
+        2
+    }
 
     fn kernel<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
         &self,
@@ -967,7 +1013,9 @@ impl Default for Multiquadric {
 }
 
 impl Kernel for Multiquadric {
-    const NB_PARAMETERS: usize = 2;
+    fn nb_parameters(&self) -> usize {
+        2
+    }
 
     fn kernel<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
         &self,
@@ -1037,7 +1085,9 @@ impl Default for RationalQuadratic {
 }
 
 impl Kernel for RationalQuadratic {
-    const NB_PARAMETERS: usize = 2;
+    fn nb_parameters(&self) -> usize {
+        2
+    }
 
     fn kernel<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
         &self,


### PR DESCRIPTION
This is necessary if we want to have a `Kernel` that's actually just a
union of mulitple possible kernels and which one is actually used is
determined at runtime.

For example, one can imagine an enum like so:

```rust
pub enum AllowedKernels {
    Matern1(friedrich::kernel::Matern1),
    Matern2(friedrich::kernel::Matern2)
}
```

and at runtime we specify which kernel to use or even change the kernel
mid-way if it's underperforming and retrain.

Without the change in the commit however, it's impossible to implement
the `Kernel` trait: we don't know ahead of time which kernel will be
used so `NB_PARAMETERS` and `IS_SCALEABLE` are not possible to implement
for unions.

As `NB_PARAMETERS` and `IS_SCALEABLE` are never used in a fashion that
actually exploits their compile-time-constness, this seems like an
acceptable change. I appreciate that we can imagine a world where we use
`NB_PARAMETERS` as an array length or that we will get rid of
`IS_SCALEABLE` in favour of a trait that stops invalid usage at compile
time. Both these changes make unions impossible again.