### PR TITLE
Resolve clippy hints

### DIFF
--- a/src/algebra/extendable_matrix.rs
+++ b/src/algebra/extendable_matrix.rs
@@ -39,7 +39,7 @@ impl EMatrix {
         }
 
         // add rows below data
-        self.data.index_mut((self.nrows.., ..)).copy_from(&rows);
+        self.data.index_mut((self.nrows.., ..)).copy_from(rows);
         self.nrows += rows.nrows();
     }
 
@@ -80,7 +80,7 @@ impl EVector {
         }
 
         // add rows below data
-        self.data.index_mut((self.nrows.., ..)).copy_from(&rows);
+        self.data.index_mut((self.nrows.., ..)).copy_from(rows);
         self.nrows += rows.nrows();
     }
 

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -48,11 +48,11 @@ pub fn make_covariance_matrix<
     m2: &SMatrix<S2>,
     kernel: &K,
 ) -> DMatrix<f64> {
-    return DMatrix::<f64>::from_fn(m1.nrows(), m2.nrows(), |r, c| {
+    DMatrix::<f64>::from_fn(m1.nrows(), m2.nrows(), |r, c| {
         let x = m1.row(r);
         let y = m2.row(c);
         kernel.kernel(&x, &y)
-    });
+    })
 }
 
 /// computes the cholesky decomposition of the covariance matrix of some inputs
@@ -77,7 +77,7 @@ pub fn make_cholesky_cov_matrix<S: Storage<f64, Dynamic, Dynamic>, K: Kernel>(
         covmatix[(col_index, col_index)] += diagonal_noise * diagonal_noise;
     }
 
-    return covmatix.cholesky().expect("Cholesky decomposition failed!");
+    covmatix.cholesky().expect("Cholesky decomposition failed!")
 }
 
 /// add rows to the covariance matrix by updating its Cholesky decomposition in place
@@ -134,5 +134,5 @@ pub fn make_gradient_covariance_matrices<S: Storage<f64, Dynamic, Dynamic>, K: K
         }
     }
 
-    return covmatrices;
+    covmatrices
 }

--- a/src/gaussian_process/builder.rs
+++ b/src/gaussian_process/builder.rs
@@ -139,8 +139,8 @@ impl<KernelType: Kernel, PriorType: Prior> GaussianProcessBuilder<KernelType, Pr
     /// The optimizer runs for a maximum of `max_iter` iterations and stops prematurely if all gradients are below `convergence_fraction` time their associated parameter.
     pub fn set_fit_parameters(self, max_iter: usize, convergence_fraction: f64) -> Self {
         GaussianProcessBuilder {
-            max_iter: max_iter,
-            convergence_fraction: convergence_fraction,
+            max_iter,
+            convergence_fraction,
             ..self
         }
     }

--- a/src/gaussian_process/mod.rs
+++ b/src/gaussian_process/mod.rs
@@ -198,7 +198,7 @@ impl<KernelType: Kernel, PriorType: Prior> GaussianProcess<KernelType, PriorType
         // formula : -1/2 (transpose(output)*cov(train,train)^-1*output + trace(log|cov(train,train)|) + size(train)*log(2*pi))
 
         // how well do we fit the trainnig data ?
-        let output = self.training_outputs.as_vector().clone();
+        let output = self.training_outputs.as_vector();
         // transpose(ol)*ol = transpose(output)*cov(train,train)^-1*output
         let ol = self
             .covmat_cholesky

--- a/src/parameters/kernel.rs
+++ b/src/parameters/kernel.rs
@@ -332,7 +332,7 @@ pub struct Linear {
 impl Linear {
     /// Constructs a new Linear Kernel.
     pub fn new(c: f64) -> Linear {
-        Linear { c: c }
+        Linear { c }
     }
 }
 
@@ -354,7 +354,7 @@ impl Kernel for Linear {
         x1: &SRowVector<S1>,
         x2: &SRowVector<S2>,
     ) -> f64 {
-        x1.dot(&x2) + self.c
+        x1.dot(x2) + self.c
     }
 
     fn gradient<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
@@ -398,9 +398,9 @@ impl Polynomial {
     /// Constructs a new Polynomial Kernel.
     pub fn new(alpha: f64, c: f64, d: f64) -> Polynomial {
         Polynomial {
-            alpha: alpha,
-            c: c,
-            d: d,
+            alpha,
+            c,
+            d,
         }
     }
 }
@@ -429,7 +429,7 @@ impl Kernel for Polynomial {
         x1: &SRowVector<S1>,
         x2: &SRowVector<S2>,
     ) -> f64 {
-        (self.alpha * x1.dot(&x2) + self.c).powf(self.d)
+        (self.alpha * x1.dot(x2) + self.c).powf(self.d)
     }
 
     fn gradient<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
@@ -437,7 +437,7 @@ impl Kernel for Polynomial {
         x1: &SRowVector<S1>,
         x2: &SRowVector<S2>,
     ) -> Vec<f64> {
-        let x = x1.dot(&x2);
+        let x = x1.dot(x2);
         let inner_term = self.alpha * x + self.c;
 
         let grad_c = self.d * inner_term.powf(self.d - 1.);
@@ -491,7 +491,7 @@ pub struct SquaredExp {
 impl SquaredExp {
     /// Construct a new squared exponential kernel (gaussian).
     pub fn new(ls: f64, ampl: f64) -> SquaredExp {
-        SquaredExp { ls: ls, ampl: ampl }
+        SquaredExp { ls, ampl }
     }
 }
 
@@ -587,7 +587,7 @@ pub struct Exponential {
 impl Exponential {
     /// Construct a new squared exponential kernel.
     pub fn new(ls: f64, ampl: f64) -> Exponential {
-        Exponential { ls: ls, ampl: ampl }
+        Exponential { ls, ampl }
     }
 }
 
@@ -683,7 +683,7 @@ pub struct Matern1 {
 impl Matern1 {
     /// Construct a new matèrn1 kernel.
     pub fn new(ls: f64, ampl: f64) -> Matern1 {
-        Matern1 { ls: ls, ampl: ampl }
+        Matern1 { ls, ampl }
     }
 }
 
@@ -781,7 +781,7 @@ pub struct Matern2 {
 impl Matern2 {
     /// Construct a new matèrn2 kernel.
     pub fn new(ls: f64, ampl: f64) -> Matern2 {
-        Matern2 { ls: ls, ampl: ampl }
+        Matern2 { ls, ampl }
     }
 }
 
@@ -883,7 +883,7 @@ pub struct HyperTan {
 impl HyperTan {
     /// Constructs a new Hyperbolic Tangent Kernel.
     pub fn new(alpha: f64, c: f64) -> HyperTan {
-        HyperTan { alpha: alpha, c: c }
+        HyperTan { alpha, c }
     }
 }
 
@@ -909,7 +909,7 @@ impl Kernel for HyperTan {
         x1: &SRowVector<S1>,
         x2: &SRowVector<S2>,
     ) -> f64 {
-        (self.alpha * x1.dot(&x2) + self.c).tanh()
+        (self.alpha * x1.dot(x2) + self.c).tanh()
     }
 
     fn gradient<S1: Storage<f64, U1, Dynamic>, S2: Storage<f64, U1, Dynamic>>(
@@ -917,7 +917,7 @@ impl Kernel for HyperTan {
         x1: &SRowVector<S1>,
         x2: &SRowVector<S2>,
     ) -> Vec<f64> {
-        let x = x1.dot(&x2);
+        let x = x1.dot(x2);
         let grad_c = 1. / (self.alpha * x + self.c).cosh().powi(2);
         let grad_alpha = x * grad_c;
 
@@ -952,7 +952,7 @@ pub struct Multiquadric {
 impl Multiquadric {
     /// Constructs a new Multiquadric Kernel.
     pub fn new(c: f64) -> Multiquadric {
-        Multiquadric { c: c }
+        Multiquadric { c }
     }
 }
 
@@ -1016,8 +1016,8 @@ impl RationalQuadratic {
     /// Constructs a new Rational Quadratic Kernel.
     pub fn new(alpha: f64, ls: f64) -> RationalQuadratic {
         RationalQuadratic {
-            alpha: alpha,
-            ls: ls,
+            alpha,
+            ls,
         }
     }
 }

--- a/src/parameters/prior.rs
+++ b/src/parameters/prior.rs
@@ -73,7 +73,7 @@ pub struct ConstantPrior {
 impl ConstantPrior {
     /// Constructs a new constant prior
     pub fn new(c: f64) -> Self {
-        Self { c: c }
+        Self { c }
     }
 }
 


### PR DESCRIPTION
Clippy lit up the code like a Christmas tree. All the changes were
pretty much trivial: use shorthand for struct initialisation, don't
double-reference and turn `.map(f)` on `Option` into `if let`.

This is on top of the rustfmt PR: #38