### PR TITLE
Export matrix aliases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,5 +37,6 @@ mod algebra;
 mod conversion;
 pub mod gaussian_process;
 mod parameters;
+pub use algebra::{SMatrix, SRowVector, SVector};
 pub use conversion::Input;
 pub use parameters::*;


### PR DESCRIPTION
Without these, it's quite annoying to implement `Kernel` outside of the
crate.